### PR TITLE
Add gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+docs/** linguist-generated=true


### PR DESCRIPTION
This tells github that the documentation is generated so that the diffs for it will be hidden by default in PRs.