### PR TITLE
Test coverage: By default, no Authorization header is used 

### DIFF
--- a/test/client-test.js
+++ b/test/client-test.js
@@ -43,6 +43,7 @@ describe('Client', () => {
       it('returns SMART OAuth URIs', async function () {
         nock(this.baseUrl)
           .matchHeader('accept', 'application/json+fhir')
+          .matchHeader('Authorization', '')
           .get('/metadata')
           .reply(200, () => readStreamFor('valid-capability-statement.json'));
 


### PR DESCRIPTION
...especially for initial requests, like GET `/metadata`.

QUESTIONS:

* Is this a legitimate thing to test for? 

* If so, is the line in this branch the way to do it?