### PR TITLE
clean-up package.json tasks

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,13 +8,13 @@
     "yarn": ">= 1.3.2"
   },
   "scripts": {
-    "docs": "./node_modules/.bin/jsdoc --configure jsdoc.json",
-    "lint": "./node_modules/.bin/eslint **/*.js --ignore-pattern node_modules/",
-    "lint:watch": "./node_modules/.bin/chokidar --initial './lib' './test' './examples' -c 'yarn lint'",
-    "test": "./node_modules/.bin/mocha test --reporter spec",
-    "test:watch": "./node_modules/.bin/chokidar --initial './lib' './test' './examples' -c 'yarn test'",
+    "docs": "jsdoc --configure jsdoc.json",
+    "lint": "eslint **/*.js --ignore-pattern node_modules/",
+    "lint:watch": "chokidar --initial './lib' './test' './examples' -c 'yarn lint'",
+    "test": "mocha test --reporter spec",
+    "test:watch": "chokidar --initial './lib' './test' './examples' -c 'yarn test'",
     "watch": "yarn test:watch & yarn lint:watch",
-    "coveralls": "./node_modules/.bin/nyc yarn test && node_modules/.bin/nyc report --reporter=text-lcov | node_modules/.bin/coveralls"
+    "coveralls": "nyc yarn test && nyc report --reporter=text-lcov | coveralls"
   },
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
* `package.json` scripts do not need `./node_moules/.bin/` path in order to reference `.bin` scripts/executables