### PR TITLE
ignore examples/node_modules (and others)

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 docs/
+node_modules


### PR DESCRIPTION
https://eslint.org/docs/user-guide/configuring

>In addition to any patterns in a .eslintignore file, ESLint always ignores files in /node_modules/* and /bower_components/*.

But, ^that apparently doesn’t apply to `/examples/node_modules`
